### PR TITLE
use-bottom-panel

### DIFF
--- a/sourcecodebrowser/ctags.py
+++ b/sourcecodebrowser/ctags.py
@@ -135,7 +135,7 @@ class Parser(object):
                         if not p in node:
                             node[p] = {'tag':None, 'children':{}}
                         node = node[p]
-                    print node
+                    print(node)
                     node['tag'] = tag                        
                 else:
                     if not parent in self.tree:

--- a/sourcecodebrowser/data/configure_dialog.ui
+++ b/sourcecodebrowser/data/configure_dialog.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="configure_dialog">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
@@ -8,6 +9,9 @@
     <property name="type_hint">dialog</property>
     <property name="skip_taskbar_hint">True</property>
     <property name="skip_pager_hint">True</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>
@@ -20,10 +24,10 @@
             <child>
               <object class="GtkButton" id="button1">
                 <property name="label">gtk-close</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -46,12 +50,31 @@
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <object class="GtkCheckButton" id="show_line_numbers">
-                <property name="label" translatable="yes">Show _line numbers in tree</property>
+              <object class="GtkCheckButton" id="use_bottom_panel">
+                <property name="label" translatable="yes">Use _bottom panel</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="on_use_bottom_panel_toggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">6</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="show_line_numbers">
+                <property name="label" translatable="yes">Show _line numbers in tree</property>
                 <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -67,10 +90,10 @@
             <child>
               <object class="GtkCheckButton" id="load_remote_files">
                 <property name="label" translatable="yes">Load symbols from _remote files</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -86,10 +109,10 @@
             <child>
               <object class="GtkCheckButton" id="expand_rows">
                 <property name="label" translatable="yes">Start with rows _expanded</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -105,10 +128,10 @@
             <child>
               <object class="GtkCheckButton" id="sort_list">
                 <property name="label" translatable="yes">_Sort list alphabetically</property>
+                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_underline">True</property>
                 <property name="xalign">0</property>
                 <property name="draw_indicator">True</property>
@@ -124,13 +147,15 @@
             <child>
               <object class="GtkBox" id="box3">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
+                    <property name="can_focus">True</property>
+                    <property name="xpad">5</property>
                     <property name="label" translatable="yes">ctags executable</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -139,18 +164,16 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry" id="ctags_executable">
+                  <object class="GtkFileChooserButton" id="ctags_executable">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <property name="text" translatable="yes">ctags</property>
-                    <property name="invisible_char_set">True</property>
-                    <signal name="changed" handler="on_ctags_executable_changed" swapped="no"/>
+                    <property name="hexpand">True</property>
+                    <property name="title" translatable="yes"/>
+                    <signal name="selection-changed" handler="on_ctags_executable_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="padding">6</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -159,6 +182,7 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="padding">6</property>
+                <property name="pack_type">end</property>
                 <property name="position">4</property>
               </packing>
             </child>

--- a/sourcecodebrowser/data/configure_dialog.ui
+++ b/sourcecodebrowser/data/configure_dialog.ui
@@ -46,6 +46,25 @@
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
             <child>
+              <object class="GtkCheckButton" id="use_bottom_panel">
+                <property name="label" translatable="yes">Use _bottom panel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_action_appearance">False</property>
+                <property name="use_underline">True</property>
+                <property name="xalign">0</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="on_use_bottom_panel_toggled" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="padding">6</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkCheckButton" id="show_line_numbers">
                 <property name="label" translatable="yes">Show _line numbers in tree</property>
                 <property name="visible">True</property>

--- a/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
+++ b/sourcecodebrowser/data/org.gnome.gedit.plugins.sourcecodebrowser.gschema.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.gedit.plugins.sourcecodebrowser" path="/org/gnome/gedit/plugins/sourcecodebrowser/">
+    <key type="b" name="use-bottom-panel">
+      <default>true</default>
+      <summary>Use bottom panel</summary>
+      <description>Use the bottom panel for the source tree.</description>
+    </key>
     <key type="b" name="show-line-numbers">
       <default>false</default>
       <summary>Show Line Numbers</summary>

--- a/sourcecodebrowser/plugin.py
+++ b/sourcecodebrowser/plugin.py
@@ -5,10 +5,13 @@ import tempfile
 from . import ctags
 from gi.repository import GObject, GdkPixbuf, Gedit, Gtk, PeasGtk, Gio
 
-import gi
-gi.require_version('Tepl', '6')
-from gi.repository import Tepl
-
+try:
+    import gi
+    gi.require_version('Tepl', '6')
+    from gi.repository import Tepl
+except:
+    Tepl = None
+    
 logging.basicConfig()
 LOG_LEVEL = logging.WARN
 SETTINGS_SCHEMA = "org.gnome.gedit.plugins.sourcecodebrowser"
@@ -36,6 +39,7 @@ class SourceTree(Gtk.VBox):
         
         # preferences (should be set by plugin)
         self.show_line_numbers = True
+        self.use_bottom_panel = False
         self.ctags_executable = 'ctags'
         self.expand_rows = True
         self.sort_list = True
@@ -267,6 +271,9 @@ class Config(object):
             builder.get_object("show_line_numbers").set_active(
                 self._settings.get_boolean('show-line-numbers')
             )
+            builder.get_object("use_bottom_panel").set_active(
+                self._settings.get_boolean('use-bottom-panel')
+            )
             builder.get_object("expand_rows").set_active(
                 self._settings.get_boolean('expand-rows')
             )
@@ -284,6 +291,9 @@ class Config(object):
     
     def on_show_line_numbers_toggled(self, button, data=None):
         self._settings.set_boolean('show-line-numbers', button.get_active())
+    
+    def on_use_bottom_panel_toggled(self, button, data=None):
+        self._settings.set_boolean('use-bottom-panel', button.get_active())
     
     def on_expand_rows_toggled(self, button, data=None):
         self._settings.set_boolean('expand-rows', button.get_active())
@@ -331,12 +341,12 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
         self._sourcetree = SourceTree()
         self._sourcetree.ctags_executable = self.ctags_executable
         self._sourcetree.show_line_numbers = self.show_line_numbers
+        self._sourcetree.use_bottom_panel = self.use_bottom_panel
         self._sourcetree.expand_rows = self.expand_rows
         self._sourcetree.sort_list = self.sort_list
-        panel = self.window.get_side_panel()
-        panel.add_titled(self._sourcetree, "SymbolBrowserPlugin", "Source Code")
+        self._insert_sourcetree_pane()
         self._handlers = []
-        hid = self._sourcetree.connect("focus", self.on_sourcetree_focus)
+        hid = self._sourcetree.connect("focus" if Tepl else "draw", self.on_sourcetree_focus)
         self._handlers.append((self._sourcetree, hid))
         if self.ctags_version is not None:
             hid = self._sourcetree.connect('tag-activated', self.on_tag_activated)
@@ -349,15 +359,33 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
             self._handlers.append((self.window, hid))
         else:
             self._sourcetree.set_sensitive(False)
-    
+
+    def _insert_sourcetree_pane(self):
+        if self._sourcetree.use_bottom_panel:
+            panel = self.window.get_bottom_panel()
+            panel.add_titled(self._sourcetree, "SymbolBrowserPlugin", "Source Tags")
+            panel.show()
+            self._sourcetree.show_all()
+            panel.set_visible_child(self._sourcetree)
+        else:
+            panel = self.window.get_side_panel()
+            panel.add_titled(self._sourcetree, "SymbolBrowserPlugin", "Source Code")
+
+    def _remove_sourcetree_pane(self):
+        if self._sourcetree.use_bottom_panel:
+            panel = self.window.get_bottom_panel()
+            panel.remove(self._sourcetree)
+        else:
+            panel = self.window.get_side_panel()
+            panel.remove(self._sourcetree)
+
     def do_deactivate(self):
         """ Deactivate the plugin """
         self._log.debug("Deactivating plugin")
         for obj, hid in self._handlers:
             obj.disconnect(hid)
         self._handlers = None
-        pane = self.window.get_side_panel()
-        pane.remove(self._sourcetree)
+        self._remove_sourcetree_pane()
         self._sourcetree = None
     
     def _has_settings_schema(self):
@@ -373,11 +401,13 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
             settings = Gio.Settings.new(SETTINGS_SCHEMA)
             self.load_remote_files = settings.get_boolean("load-remote-files")
             self.show_line_numbers = settings.get_boolean("show-line-numbers")
+            self.use_bottom_panel = settings.get_boolean("use-bottom-panel")
             self.expand_rows = settings.get_boolean("expand-rows")
             self.sort_list = settings.get_boolean("sort-list")
             self.ctags_executable = settings.get_string("ctags-executable")
             settings.connect("changed::load-remote-files", self.on_setting_changed)
             settings.connect("changed::show-line-numbers", self.on_setting_changed)
+            settings.connect("changed::use-bottom-panel", self.on_setting_changed)
             settings.connect("changed::expand-rows", self.on_setting_changed)
             settings.connect("changed::sort-list", self.on_setting_changed)
             settings.connect("changed::ctags-executable", self.on_setting_changed)
@@ -387,6 +417,7 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
             self._settings = None
             self.load_remote_files = True
             self.show_line_numbers = False
+            self.use_bottom_panel = False
             self.expand_rows = True
             self.sort_list = True
             self.ctags_executable = 'ctags'
@@ -396,7 +427,11 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
         self._sourcetree.clear()
         self._is_loaded = False
         # do not load if not the active tab in the panel
-        panel = self.window.get_side_panel()
+        if self._sourcetree.use_bottom_panel:
+            panel = self.window.get_bottom_panel()
+            panel.props.visible_child = self._sourcetree
+        else:
+            panel = self.window.get_side_panel()
         if panel.get_visible_child() != self._sourcetree:
             return
 
@@ -433,6 +468,7 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
         """
         self.load_remote_files = True
         self.show_line_numbers = False
+        self.use_bottom_panel = False
         self.expand_rows = True
         self.ctags_executable = 'ctags'
         """
@@ -440,6 +476,8 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
             self.load_remote_files = self._settings.get_boolean(key)
         elif key == 'show-line-numbers':
             self.show_line_numbers = self._settings.get_boolean(key)
+        elif key == 'use-bottom-panel':
+            self.use_bottom_panel = self._settings.get_boolean(key)
         elif key == 'expand-rows':
             self.expand_rows = self._settings.get_boolean(key)
         elif key == 'sort-list':
@@ -450,6 +488,9 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
         if self._sourcetree is not None:
             self._sourcetree.ctags_executable = self.ctags_executable
             self._sourcetree.show_line_numbers = self.show_line_numbers
+            self._remove_sourcetree_pane()
+            self._sourcetree.use_bottom_panel = self.use_bottom_panel
+            self._insert_sourcetree_pane()
             self._sourcetree.expand_rows = self.expand_rows
             self._sourcetree.sort_list = self.sort_list
             self._sourcetree.expanded_rows = {}
@@ -474,8 +515,11 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
         document = self.window.get_active_document()
         view = self.window.get_active_view()
         line = int(line) - 1 # lines start from 0
-       
-        Tepl.View.goto_line(view, line)
+        if Tepl:
+            Tepl.View.goto_line(view, line)
+        else:
+            document.goto_line(line)
+            view.scroll_to_cursor()
         
     def _version_check(self):
         """ Make sure the exhuberant ctags is installed. """


### PR DESCRIPTION
This is how i made the gedit-source-code-browser optionally available on the bottom panel instead of the side panel in Gedit. Advantage is that i can access the tags of all the loaded documents with less clicking.
It is an option called 'Use bottom panel' that can be set or unset through the config dialog in the 'Preferences Plugins' menu.
Also i made the plugin functioning with Gedit 3.36... For that i had to wrap the 'import Tepl'-statement in a 'try...except...'-construct plus adding some 'if Tepl'-constructs.